### PR TITLE
Using OT::FittingTest::ChiSquared for normality test

### DIFF
--- a/lib/test/t_LinearModelAnalysis_std.expout
+++ b/lib/test/t_LinearModelAnalysis_std.expout
@@ -15,13 +15,13 @@ Multiple R-squared   | 0.999986 |
 Adjusted R-squared   | 0.999985 |
 ---------------------------------
 
-------------------------------------
-Normality test       | p-value     |
-------------------------------------
-Anderson-Darling     | 0.00258386  |
-Chi-Squared          | 0.000276115 |
-Kolmogorov-Smirnov   | 0.17747     |
-------------------------------------
+-----------------------------------
+Normality test       | p-value    |
+-----------------------------------
+Anderson-Darling     | 0.00258386 |
+Chi-Squared          | 0.157724   |
+Kolmogorov-Smirnov   | 0.17747    |
+-----------------------------------
 
 Confidence intervals with level=0.95 : class=Interval name=Unnamed dimension=2 lower bound=class=Point name=Unnamed dimension=2 values=[2.99229,-2.00396] upper bound=class=Point name=Unnamed dimension=2 values=[3.03106,-1.99655] finite lower bound=[1,1] finite upper bound=[1,1]
 
@@ -49,7 +49,7 @@ Adjusted R-squared   | 1 |
 Normality test       | p-value  |
 ---------------------------------
 Anderson-Darling     | 0.57332  |
-Chi-Squared          | 0.663954 |
+Chi-Squared          | 0.783691 |
 Kolmogorov-Smirnov   | 0.821849 |
 ---------------------------------
 

--- a/python/test/t_LinearModelAnalysis_std.expout
+++ b/python/test/t_LinearModelAnalysis_std.expout
@@ -15,13 +15,13 @@ Multiple R-squared   | 0.999986 |
 Adjusted R-squared   | 0.999985 |
 ---------------------------------
 
-------------------------------------
-Normality test       | p-value     |
-------------------------------------
-Anderson-Darling     | 0.00258386  |
-Chi-Squared          | 0.000276115 |
-Kolmogorov-Smirnov   | 0.17747     |
-------------------------------------
+-----------------------------------
+Normality test       | p-value    |
+-----------------------------------
+Anderson-Darling     | 0.00258386 |
+Chi-Squared          | 0.157724   |
+Kolmogorov-Smirnov   | 0.17747    |
+-----------------------------------
 
 confidence intervals with level=0.95 : [2.99568, 3.02768]
 [-2.00331, -1.9972]
@@ -50,7 +50,7 @@ Adjusted R-squared   | 1 |
 Normality test       | p-value  |
 ---------------------------------
 Anderson-Darling     | 0.57332  |
-Chi-Squared          | 0.663954 |
+Chi-Squared          | 0.783691 |
 Kolmogorov-Smirnov   | 0.821849 |
 ---------------------------------
 

--- a/python/test/t_LinearModelStepwiseAlgorithm_std.expout
+++ b/python/test/t_LinearModelStepwiseAlgorithm_std.expout
@@ -22,7 +22,7 @@ Adjusted R-squared   | 0.642168 |
 Normality test       | p-value     |
 ------------------------------------
 Anderson-Darling     | 0.000429122 |
-Chi-Squared          | 0.000909433 |
+Chi-Squared          | 0.0553713   |
 Kolmogorov-Smirnov   | 0.0481525   |
 ------------------------------------
 
@@ -52,7 +52,7 @@ Adjusted R-squared   | 0.642344 |
 Normality test       | p-value    |
 -----------------------------------
 Anderson-Darling     | 0.00124009 |
-Chi-Squared          | 0.0204981  |
+Chi-Squared          | 0.063153   |
 Kolmogorov-Smirnov   | 0.338063   |
 -----------------------------------
 
@@ -80,7 +80,7 @@ Adjusted R-squared   | 0.642168 |
 Normality test       | p-value     |
 ------------------------------------
 Anderson-Darling     | 0.000429122 |
-Chi-Squared          | 0.000909433 |
+Chi-Squared          | 0.0553713   |
 Kolmogorov-Smirnov   | 0.0481525   |
 ------------------------------------
 
@@ -108,7 +108,7 @@ Adjusted R-squared   | 0.642168 |
 Normality test       | p-value     |
 ------------------------------------
 Anderson-Darling     | 0.000429122 |
-Chi-Squared          | 0.000909433 |
+Chi-Squared          | 0.0553713   |
 Kolmogorov-Smirnov   | 0.0481525   |
 ------------------------------------
 
@@ -132,13 +132,13 @@ Multiple R-squared   | 0.647576 |
 Adjusted R-squared   | 0.630794 |
 ---------------------------------
 
-------------------------------------
-Normality test       | p-value     |
-------------------------------------
-Anderson-Darling     | 0.00130208  |
-Chi-Squared          | 0.000909433 |
-Kolmogorov-Smirnov   | 0.121207    |
-------------------------------------
+-----------------------------------
+Normality test       | p-value    |
+-----------------------------------
+Anderson-Darling     | 0.00130208 |
+Chi-Squared          | 0.0719171  |
+Kolmogorov-Smirnov   | 0.121207   |
+-----------------------------------
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  Both  BIC 
@@ -164,7 +164,7 @@ Adjusted R-squared   | 0.642168 |
 Normality test       | p-value     |
 ------------------------------------
 Anderson-Darling     | 0.000429122 |
-Chi-Squared          | 0.000909433 |
+Chi-Squared          | 0.0553713   |
 Kolmogorov-Smirnov   | 0.0481525   |
 ------------------------------------
 


### PR DESCRIPTION
Remove specific implementation of ChiSquared fitting test & use the new OT API