### PR TITLE
LinearModelAlgorithm does not rely on LinearModelStepwiseAlgorithm

### DIFF
--- a/lib/src/LinearModelResult.cxx
+++ b/lib/src/LinearModelResult.cxx
@@ -21,7 +21,6 @@
 #include "otlm/LinearModelResult.hxx"
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/DatabaseFunction.hxx"
-#include "openturns/LinearModel.hxx"
 #include "openturns/OSS.hxx"
 #include "openturns/OTthread.hxx"
 
@@ -53,6 +52,7 @@ public:
       ResourceMap::SetAsUnsignedInteger("LinearModelAnalysis-Identifiers", 3);
 
       ResourceMap::SetAsBool("LinearModelStepwiseAlgorithm-normalize", true);
+      ResourceMap::SetAsString("LinearModelAlgorithm-DecompositionMethod", "QR");
 
       OTLMResourceMap_initialized_ = 1;
     }


### PR DESCRIPTION
Now we use the `LeastSquaresMethod` classes to solve the least square problem and get the various quantities of interest (leverage, diagonal of the inverse gram)

This work helps the future integration of LinearModelAlgorithm/LinearModelResult in the OT API as we might integrate the standard `LinearModelAlgorithm` and its `LinearModelResult` result class